### PR TITLE
eslint: Allow version 8 to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=10"
   },
   "peerDependencies": {
-    "eslint": ">= 3.0.0 <= 7.x.x"
+    "eslint": ">= 3.0.0 <= 8.x.x"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Any reason why eslint 8 is not valid as peerDependency? Seems to work just fine :-)
